### PR TITLE
Fixed PID issue with CM108B

### DIFF
--- a/cm108_ptt.hh
+++ b/cm108_ptt.hh
@@ -21,7 +21,7 @@ public:
     bool open(const int gpio){
         res_ = hid_init();
         gpio_ = gpio;
-        handle_ = hid_open(0x0D8C, 0x013C, NULL);
+        handle_ = hid_open(0x0D8C, 0x0012, NULL);
         if (!handle_) {
             std::cerr << "Failed to open CM108 PTT via USB" << std::endl;
             hid_exit();


### PR DESCRIPTION
This is a fix for CM108B-based chips as 0x013c is the PID of another CMedia chip (HS100).
I used a CM108B-based interface with an incorrectly-flashed EEPROM to test my previously-contributed code (my bad).

I'll need to update the code to be able to :
- Choose which CM108-compatible chip to use.
- Target a specific chip which will be useful in more complex setups using several such interfaces.